### PR TITLE
Adding the possibility to redact Sitter info about themselves.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added 
 
 - Add new templates for `epic` issue and `feature request` - [4](https://github.com/IronFoundation/iOS-Woof/pull/4)
-- Add the possibility to redact `Sitter` info about themselves - [52](https://github.com/IronFoundation/iOS-Woof/pull/52)
+- Add the possibility for sitters to update info about themselves - [52](https://github.com/IronFoundation/iOS-Woof/pull/52)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added 
 
 - Add new templates for `epic` issue and `feature request` - [4](https://github.com/IronFoundation/iOS-Woof/pull/4)
+- Add the possibility to redact `Sitter` info about themselves - [52](https://github.com/IronFoundation/iOS-Woof/pull/52)
 
 ### Changed
 

--- a/Woof/Woof.xcodeproj/project.pbxproj
+++ b/Woof/Woof.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		362732A22A1B800B0062E4B5 /* KeyValueStorageDeleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 362732A12A1B800A0062E4B5 /* KeyValueStorageDeleteTests.swift */; };
 		362F63062A28A8B6002A659B /* OwnerProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 362F63052A28A8B6002A659B /* OwnerProfileView.swift */; };
 		363528D62AB9ADF6009A21CF /* Sitter+CodingKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363528D52AB9ADF6009A21CF /* Sitter+CodingKeys.swift */; };
+		3638A46C2AD42FB8005A20F0 /* KeyValueStorageClearStoredSitterData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3638A46B2AD42FB8005A20F0 /* KeyValueStorageClearStoredSitterData.swift */; };
 		365D3F2A2A38891D00EC9B30 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E97F162A2F42FD00030E3E /* LoginViewModel.swift */; };
 		3673D6372A04F7FD009D699D /* Owner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3673D6362A04F7FD009D699D /* Owner.swift */; };
 		368BF0EC2A152FA500F3F750 /* KeyValueStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368BF0EB2A152FA500F3F750 /* KeyValueStorage.swift */; };
@@ -205,6 +206,7 @@
 		362732A12A1B800A0062E4B5 /* KeyValueStorageDeleteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValueStorageDeleteTests.swift; sourceTree = "<group>"; };
 		362F63052A28A8B6002A659B /* OwnerProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OwnerProfileView.swift; sourceTree = "<group>"; };
 		363528D52AB9ADF6009A21CF /* Sitter+CodingKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sitter+CodingKeys.swift"; sourceTree = "<group>"; };
+		3638A46B2AD42FB8005A20F0 /* KeyValueStorageClearStoredSitterData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValueStorageClearStoredSitterData.swift; sourceTree = "<group>"; };
 		3673D6362A04F7FD009D699D /* Owner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Owner.swift; sourceTree = "<group>"; };
 		368BF0EB2A152FA500F3F750 /* KeyValueStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValueStorage.swift; sourceTree = "<group>"; };
 		368F66602A308D2600C8F69D /* PreferencesHandlerGetUserRoleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesHandlerGetUserRoleTests.swift; sourceTree = "<group>"; };
@@ -410,6 +412,14 @@
 			path = AppError;
 			sourceTree = "<group>";
 		};
+		3638A46A2AD42F55005A20F0 /* Helper */ = {
+			isa = PBXGroup;
+			children = (
+				3638A46B2AD42FB8005A20F0 /* KeyValueStorageClearStoredSitterData.swift */,
+			);
+			path = Helper;
+			sourceTree = "<group>";
+		};
 		36BEA7592A1621B70020F6AE /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -526,6 +536,7 @@
 		EF4CBAED2A3C6FF100B4A223 /* SitterProfileViewModelTests */ = {
 			isa = PBXGroup;
 			children = (
+				3638A46A2AD42F55005A20F0 /* Helper */,
 				EF4CBAEE2A3C704300B4A223 /* Sitter+Tests.swift */,
 				EF4CBAF12A3C708E00B4A223 /* SitterProfileViewModelTests.swift */,
 				EF4CBAF42A3C712C00B4A223 /* SitterProfileViewModelSaveTests.swift */,
@@ -1277,6 +1288,7 @@
 				1934CC362AB9BC1E001D5CB4 /* DummyServerResponseData.swift in Sources */,
 				EF4CBAF02A3C704300B4A223 /* Sitter+Tests.swift in Sources */,
 				FDD144012A0532D5000BBA77 /* String+IconNameTests.swift in Sources */,
+				3638A46C2AD42FB8005A20F0 /* KeyValueStorageClearStoredSitterData.swift in Sources */,
 				FD02917B2A0E2C5300F88377 /* AppStyle+UIElementConstant.swift in Sources */,
 				FDEE43CE2A2F4E56007DE0A9 /* Preferences.swift in Sources */,
 				1934CC332AB9B79E001D5CB4 /* SitterListViewModelTests.swift in Sources */,

--- a/Woof/Woof/View/SitterFlow/SitterProfileView/SitterProfileView.swift
+++ b/Woof/Woof/View/SitterFlow/SitterProfileView/SitterProfileView.swift
@@ -52,12 +52,6 @@ struct SitterProfileView: View {
                         ratePerHour: viewModel.pricePerHour,
                         city: viewModel.city
                     )
-
-                    if !viewModel.sitterIsSet {
-                        Button(editButtonLabelText) {
-                            viewModel.isEditingMode.toggle()
-                        }
-                    }
                 }
                 .buttonStyle(CapsuleWithWhiteText())
                 .padding()

--- a/Woof/Woof/View/SitterFlow/SitterProfileView/SitterProfileView.swift
+++ b/Woof/Woof/View/SitterFlow/SitterProfileView/SitterProfileView.swift
@@ -53,6 +53,10 @@ struct SitterProfileView: View {
                         ratePerHour: viewModel.pricePerHour,
                         city: viewModel.city
                     )
+
+                    Button(editButtonLabelText) {
+                        viewModel.isEditingMode.toggle()
+                    }
                 }
                 .buttonStyle(CapsuleWithWhiteText())
                 .padding()

--- a/Woof/Woof/ViewModel/SitterProfileViewModel.swift
+++ b/Woof/Woof/ViewModel/SitterProfileViewModel.swift
@@ -73,8 +73,13 @@ final class SitterProfileViewModel: ObservableObject {
         newSitter.pricePerHour = Double(pricePerHour) ?? 0
 
         do {
-            try await upload(newSitter)
-            try await saveLocally(newSitter)
+            if sitterIsSet {
+                try await update(newSitter)
+                try await saveLocally(newSitter)
+            } else {
+                try await upload(newSitter)
+                try await saveLocally(newSitter)
+            }
             currentSitter = newSitter
             isEditingMode = false
         } catch {
@@ -100,6 +105,16 @@ final class SitterProfileViewModel: ObservableObject {
 
     private func upload(_ sitter: Sitter) async throws {
         let endpoint = WoofAppEndpoint.addNewSitter(sitter.asDictionary())
+
+        do {
+            _ = try await NetworkService<WoofAppEndpoint>().request(endpoint)
+        } catch {
+            throw AppError.uploadFailed
+        }
+    }
+
+    private func update(_ sitter: Sitter) async throws {
+        let endpoint = WoofAppEndpoint.updateSitter(sitter.asDictionary())
 
         do {
             _ = try await NetworkService<WoofAppEndpoint>().request(endpoint)

--- a/Woof/Woof/ViewModel/SitterProfileViewModel.swift
+++ b/Woof/Woof/ViewModel/SitterProfileViewModel.swift
@@ -65,7 +65,7 @@ final class SitterProfileViewModel: ObservableObject {
     @MainActor func save() async {
         isSavingData = true
 
-        var newSitter = Sitter()
+        var newSitter = currentSitter ?? Sitter()
         newSitter.name = name
         newSitter.surname = surname
         newSitter.phone = phone
@@ -76,11 +76,10 @@ final class SitterProfileViewModel: ObservableObject {
         do {
             if sitterIsSet {
                 try await update(newSitter)
-                try await saveLocally(newSitter)
             } else {
                 try await upload(newSitter)
-                try await saveLocally(newSitter)
             }
+            try await saveLocally(newSitter)
             currentSitter = newSitter
             isEditingMode = false
         } catch {

--- a/Woof/Woof/ViewModel/SitterProfileViewModel.swift
+++ b/Woof/Woof/ViewModel/SitterProfileViewModel.swift
@@ -103,11 +103,13 @@ final class SitterProfileViewModel: ObservableObject {
         }
     }
 
+    private let networkService = NetworkService<WoofAppEndpoint>()
+
     private func upload(_ sitter: Sitter) async throws {
         let endpoint = WoofAppEndpoint.addNewSitter(sitter.asDictionary())
 
         do {
-            _ = try await NetworkService<WoofAppEndpoint>().request(endpoint)
+            _ = try await networkService.request(endpoint)
         } catch {
             throw AppError.uploadFailed
         }
@@ -117,7 +119,7 @@ final class SitterProfileViewModel: ObservableObject {
         let endpoint = WoofAppEndpoint.updateSitter(sitter.asDictionary())
 
         do {
-            _ = try await NetworkService<WoofAppEndpoint>().request(endpoint)
+            _ = try await networkService.request(endpoint)
         } catch {
             throw AppError.uploadFailed
         }

--- a/Woof/WoofTests/ViewModel/SitterProfileViewModelTests/Helper/KeyValueStorageClearStoredSitterData.swift
+++ b/Woof/WoofTests/ViewModel/SitterProfileViewModelTests/Helper/KeyValueStorageClearStoredSitterData.swift
@@ -1,0 +1,7 @@
+extension KeyValueStorage {
+    /// Clears stored sitters data from storage.
+    static func clearStoredSitterData() {
+        let keyValueStorage = KeyValueStorage(KeyValueStorage.Name.currentSitter)
+        keyValueStorage.deleteData(for: KeyValueStorage.Key.currentSitter)
+    }
+}

--- a/Woof/WoofTests/ViewModel/SitterProfileViewModelTests/Helper/KeyValueStorageClearStoredSitterData.swift
+++ b/Woof/WoofTests/ViewModel/SitterProfileViewModelTests/Helper/KeyValueStorageClearStoredSitterData.swift
@@ -1,7 +1,6 @@
 extension KeyValueStorage {
     /// Clears stored sitters data from storage.
     static func clearStoredSitterData() {
-        let keyValueStorage = KeyValueStorage(KeyValueStorage.Name.currentSitter)
-        keyValueStorage.deleteData(for: KeyValueStorage.Key.currentSitter)
+        KeyValueStorage(Self.Name.currentSitter).deleteData(for: Self.Key.currentSitter)
     }
 }

--- a/Woof/WoofTests/ViewModel/SitterProfileViewModelTests/SitterProfileViewModelSaveTests.swift
+++ b/Woof/WoofTests/ViewModel/SitterProfileViewModelTests/SitterProfileViewModelSaveTests.swift
@@ -6,7 +6,6 @@ final class SitterProfileViewModelSaveTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        KeyValueStorage.clearStoredSitterData()
         URLProtocol.registerClass(MockURLProtocol.self)
         viewModel = SitterProfileViewModel()
     }
@@ -130,7 +129,7 @@ final class SitterProfileViewModelSaveTests: XCTestCase {
         XCTAssertEqual(requestCount, 1)
     }
 
-    func testFirstSaveChangesSitterIsSet() async {
+    func testFirstSavedSitterChangesSitterIsSetPropertyOnTrue() async {
         // Given
         MockURLProtocol.requestHandler = { request in
             let response = try XCTUnwrap(
@@ -152,7 +151,7 @@ final class SitterProfileViewModelSaveTests: XCTestCase {
         XCTAssertNotEqual(sitterIsSetBeforeSave, viewModel.sitterIsSet)
     }
 
-    func testSitterIsSetIsNotChangedWhenSaveCalledTwice() async {
+    func testSitterIsSetIsTrueWhenSaveIsCalledRepeatedly() async {
         // Given
         MockURLProtocol.requestHandler = { request in
             let response = try XCTUnwrap(

--- a/Woof/WoofTests/ViewModel/SitterProfileViewModelTests/SitterProfileViewModelSaveTests.swift
+++ b/Woof/WoofTests/ViewModel/SitterProfileViewModelTests/SitterProfileViewModelSaveTests.swift
@@ -142,13 +142,13 @@ final class SitterProfileViewModelSaveTests: XCTestCase {
             )
             return (response, nil)
         }
+        XCTAssertFalse(viewModel.sitterIsSet)
 
         // When
-        let sitterIsSetBeforeSave = viewModel.sitterIsSet
         await viewModel.save()
 
         // Then
-        XCTAssertNotEqual(sitterIsSetBeforeSave, viewModel.sitterIsSet)
+        XCTAssertTrue(viewModel.sitterIsSet)
     }
 
     func testSitterIsSetIsTrueWhenSaveIsCalledRepeatedly() async {

--- a/Woof/WoofTests/ViewModel/SitterProfileViewModelTests/SitterProfileViewModelSaveTests.swift
+++ b/Woof/WoofTests/ViewModel/SitterProfileViewModelTests/SitterProfileViewModelSaveTests.swift
@@ -147,14 +147,12 @@ final class SitterProfileViewModelSaveTests: XCTestCase {
         // When
         let sitterIsSetBeforeSave = viewModel.sitterIsSet
         await viewModel.save()
-        let sitterIsSetAfterSave = viewModel.sitterIsSet
 
         // Then
-        XCTAssertFalse(sitterIsSetBeforeSave)
-        XCTAssertTrue(sitterIsSetAfterSave)
+        XCTAssertNotEqual(sitterIsSetBeforeSave, viewModel.sitterIsSet)
     }
 
-    func testSecondSaveDoesntChangeSitterIsSet() async {
+    func testSitterIsSetIsNotChangedWhenSaveCalledTwice() async {
         // Given
         MockURLProtocol.requestHandler = { request in
             let response = try XCTUnwrap(
@@ -170,11 +168,9 @@ final class SitterProfileViewModelSaveTests: XCTestCase {
 
         // When
         await viewModel.save()
-        let sitterIsSetBeforeSecondSave = viewModel.sitterIsSet
         await viewModel.save()
-        let sitterIsSetAfterSecondSave = viewModel.sitterIsSet
 
         // Then
-        XCTAssertEqual(sitterIsSetBeforeSecondSave, sitterIsSetAfterSecondSave)
+        XCTAssertTrue(viewModel.sitterIsSet)
     }
 }

--- a/Woof/WoofTests/ViewModel/SitterProfileViewModelTests/SitterProfileViewModelSaveTests.swift
+++ b/Woof/WoofTests/ViewModel/SitterProfileViewModelTests/SitterProfileViewModelSaveTests.swift
@@ -6,11 +6,13 @@ final class SitterProfileViewModelSaveTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        KeyValueStorage.clearStoredSitterData()
         URLProtocol.registerClass(MockURLProtocol.self)
         viewModel = SitterProfileViewModel()
     }
 
     override func tearDown() {
+        KeyValueStorage.clearStoredSitterData()
         URLProtocol.unregisterClass(MockURLProtocol.self)
         viewModel = nil
         super.tearDown()
@@ -126,5 +128,53 @@ final class SitterProfileViewModelSaveTests: XCTestCase {
 
         // Then
         XCTAssertEqual(requestCount, 1)
+    }
+
+    func testFirstSaveChangesSitterIsSet() async {
+        // Given
+        MockURLProtocol.requestHandler = { request in
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+            return (response, nil)
+        }
+
+        // When
+        let sitterIsSetBeforeSave = viewModel.sitterIsSet
+        await viewModel.save()
+        let sitterIsSetAfterSave = viewModel.sitterIsSet
+
+        // Then
+        XCTAssertFalse(sitterIsSetBeforeSave)
+        XCTAssertTrue(sitterIsSetAfterSave)
+    }
+
+    func testSecondSaveDoesntChangeSitterIsSet() async {
+        // Given
+        MockURLProtocol.requestHandler = { request in
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+            return (response, nil)
+        }
+
+        // When
+        await viewModel.save()
+        let sitterIsSetBeforeSecondSave = viewModel.sitterIsSet
+        await viewModel.save()
+        let sitterIsSetAfterSecondSave = viewModel.sitterIsSet
+
+        // Then
+        XCTAssertEqual(sitterIsSetBeforeSecondSave, sitterIsSetAfterSecondSave)
     }
 }

--- a/Woof/WoofTests/ViewModel/SitterProfileViewModelTests/SitterProfileViewModelSaveTests.swift
+++ b/Woof/WoofTests/ViewModel/SitterProfileViewModelTests/SitterProfileViewModelSaveTests.swift
@@ -129,7 +129,7 @@ final class SitterProfileViewModelSaveTests: XCTestCase {
         XCTAssertEqual(requestCount, 1)
     }
 
-    func testFirstSavedSitterChangesSitterIsSetPropertyOnTrue() async {
+    func testFirstSavedSitterChangesSitterIsSetPropertyToTrue() async {
         // Given
         MockURLProtocol.requestHandler = { request in
             let response = try XCTUnwrap(


### PR DESCRIPTION
<!-- Add a meaningful description of the changes you made -->
## Summary
This PR is a part of the work to resolve #44

<!-- Some description of HOW you achieved it. Perhaps give a high-level description of the program flow. 
Did you need to refactor something? What tradeoffs did you take? 
Are there things in here that you’d particularly like people to pay close attention to? -->
## Changes in:
- SitterProfileViewModel, added private method `update()` to use with PUT request
- SitterProfileView, the `edit` button is always shown.

<!-- Go through the checklist below to verify that your PR is good and ready for review -->
## Checks to complete
- [x] The PR title has a conventional commit style (short and descriptive).
- [x] The PR description includes essential information that helps understand the purpose of the changes.
- [x] I've built and run my changes, and no warnings or errors occurred.
- [x] All existing tests passed with my changes.
- [x] My code follows our style guide.
- [x] I've performed a self-review of my code.
- [x] Every non-private interface is documented properly.
- [x] I've added tests for my code (if it makes sense).
- [x] I've updated `CHANGELOG.md` file.
- [x] PR has assignee, reviewers, milestone, it is properly linked to the project and to the issue.
