### PR TITLE
Update ci

### DIFF
--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -8,13 +8,13 @@ on:
 
 jobs:
   build-and-test-woof-app:
-    runs-on: macos-14-large
+    runs-on: macos-13
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Setup environment
-        run: sudo xcode-select -s /Applications/Xcode_15.3.app
+        run: sudo xcode-select -s /Applications/Xcode_15.2.app
 
       - name: Cache Swift dependencies
         uses: actions/cache@v4
@@ -34,7 +34,7 @@ jobs:
         run: ./scripts/run-unit-tests.sh
 
   run-linter-and-formater:
-    runs-on: macos-14-large
+    runs-on: macos-13
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -19,3 +19,15 @@ jobs:
 
       - name: Run tests
         run: ./scripts/run-unit-tests.sh
+
+      - name: Run formater
+        run: |
+         swiftformat --lint . \
+         --config .swiftformat \
+         --quiet
+
+      - name: Run linter
+        run: |
+         swiftlint --config .swiftlint.yml \
+         --strict \
+         --quiet

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -14,7 +14,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup environment
-        run: sudo xcode-select -s /Applications/Xcode_15.2.app
+        env: 
+          XCODE_VERSION: 15.2
+        run: sudo xcode-select -s /Applications/Xcode_${{env.XCODE_VERSION}}.app
 
       - name: Cache Swift dependencies
         uses: actions/cache@v4

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -39,6 +39,13 @@ jobs:
       - name: Run formater
         continue-on-error: true
         run: |
+         brew uninstall swiftformat
+         git clone https://github.com/nicklockwood/SwiftFormat
+         cd SwiftFormat
+         git checkout 0.52.8
+         swift build -c release
+         export PATH="'$(pwd)'/.build/release/:$PATH"
+
          swiftformat --lint . \
          --config .swiftformat \
          --quiet

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-test-woof-app:
-    runs-on: macos-13
+    runs-on: macos-14-large
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
         run: ./scripts/run-unit-tests.sh
 
   run-linter-and-formater:
-    runs-on: macos-13
+    runs-on: macos-14-large
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -7,6 +7,20 @@ on:
     - cron: "15 4,5 * * *"
 
 jobs:
+  SwiftLint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: GitHub Action for SwiftLint
+        uses: norio-nomura/action-swiftlint@3.2.1
+      - name: GitHub Action for SwiftLint with --strict
+        uses: norio-nomura/action-swiftlint@3.2.1
+        with:
+          args: --strict
+      - name: GitHub Action for SwiftLint (Only files changed in the PR)
+        uses: norio-nomura/action-swiftlint@3.2.1
+        env:
+          DIFF_BASE: ${{ github.base_ref }}
   build-woof-target:
     runs-on: macos-14
     steps:
@@ -35,9 +49,9 @@ jobs:
          swiftformat --lint . \
          --config .swiftformat \
          --quiet
-
-      - name: Run linter
-        run: |
-         swiftlint --config .swiftlint.yml \
-         --strict \
-         --quiet
+#
+#      - name: Run linter
+#        run: |
+#         swiftlint --config .swiftlint.yml \
+#         --strict \
+#         --quiet

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -7,7 +7,7 @@ on:
     - cron: "15 4,5 * * *"
 
 jobs:
-  build-woof-target:
+  build-and-test-woof-app:
     runs-on: macos-13
     steps:
       - name: Checkout repository
@@ -30,6 +30,12 @@ jobs:
       - name: Run tests
         run: ./scripts/run-unit-tests.sh
 
+  run-linter-and-formater:
+    runs-on: macos-13
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
       - name: Run formater
         run: |
          swiftformat --lint . \

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -7,22 +7,8 @@ on:
     - cron: "15 4,5 * * *"
 
 jobs:
-  SwiftLint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: GitHub Action for SwiftLint
-        uses: norio-nomura/action-swiftlint@3.2.1
-      - name: GitHub Action for SwiftLint with --strict
-        uses: norio-nomura/action-swiftlint@3.2.1
-        with:
-          args: --strict
-      - name: GitHub Action for SwiftLint (Only files changed in the PR)
-        uses: norio-nomura/action-swiftlint@3.2.1
-        env:
-          DIFF_BASE: ${{ github.base_ref }}
   build-woof-target:
-    runs-on: macos-14
+    runs-on: macos-13
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -49,9 +35,9 @@ jobs:
          swiftformat --lint . \
          --config .swiftformat \
          --quiet
-#
-#      - name: Run linter
-#        run: |
-#         swiftlint --config .swiftlint.yml \
-#         --strict \
-#         --quiet
+
+      - name: Run linter
+        run: |
+         swiftlint --config .swiftlint.yml \
+         --strict \
+         --quiet

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -1,13 +1,13 @@
-name: build-app
+name: build-and-test
 run-name: build app from the ${{ github.head_ref }} branch
 on: pull_request
 jobs:
   build-woof-target:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Setup environment
-        run: ./scripts/set-up-environment.sh
       - name: Build iOS Simulator
         run: ./scripts/build-ios-simulator.sh
+      - name: Run tests
+        run: ./scripts/run-unit-tests.sh

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -39,13 +39,6 @@ jobs:
       - name: Run formater
         continue-on-error: true
         run: |
-         brew uninstall swiftformat
-         git clone https://github.com/nicklockwood/SwiftFormat
-         cd SwiftFormat
-         git checkout 0.52.8
-         swift build -c release
-         export PATH="'$(pwd)'/.build/release/:$PATH"
-
          swiftformat --lint . \
          --config .swiftformat \
          --quiet

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup environment
-        run: ./scripts/set-up-environment.sh
+        run: sudo xcode-select -s /Applications/Xcode_15.3.app
 
       - name: Cache Swift dependencies
         uses: actions/cache@v4

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -57,13 +57,13 @@ jobs:
       - name: Run tests
         run: ./scripts/run-unit-tests.sh
 
-  run-linter-and-formater:
+  run-linter-and-formatter:
     runs-on: macos-13
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         
-      - name: Run formater
+      - name: Run formatter
         continue-on-error: true
         run: |
          swiftformat --lint . \

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -14,6 +14,11 @@ jobs:
          path: ~/.swiftpm
          key: ${{ runner.os }}-swift-${{ hashFiles('**/Package.resolved') }}
 
+      - name: Install xcpretty
+        run: |
+         gem install xcpretty
+         echo 'export PATH="$(gem environment gemdir)/bin:$PATH"' >> ~/.bash_profile
+
       - name: Build iOS Simulator
         run: ./scripts/build-ios-simulator.sh
 

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -7,7 +7,7 @@ on:
     - cron: "15 4,5 * * *"
 
 jobs:
-  build-and-test-woof-app:
+  build-app:
     runs-on: macos-13
     steps:
       - name: Checkout repository
@@ -31,6 +31,28 @@ jobs:
 
       - name: Build iOS Simulator
         run: ./scripts/build-ios-simulator.sh
+
+  test-woof-app:
+    runs-on: macos-13
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Setup environment
+        env: 
+          XCODE_VERSION: 15.2
+        run: sudo xcode-select -s /Applications/Xcode_${{env.XCODE_VERSION}}.app
+
+      - name: Cache Swift dependencies
+        uses: actions/cache@v4
+        with:
+         path: ~/.swiftpm
+         key: ${{ runner.os }}-swift-${{ hashFiles('**/Package.resolved') }}
+
+      - name: Install xcpretty
+        run: |
+         gem install xcpretty
+         echo 'export PATH="$(gem environment gemdir)/bin:$PATH"' >> ~/.bash_profile
 
       - name: Run tests
         run: ./scripts/run-unit-tests.sh

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -13,6 +13,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup environment
+        run: ./scripts/set-up-environment.sh
+
       - name: Cache Swift dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -7,7 +7,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Cache Swift dependencies
+        uses: actions/cache@v4
+        with:
+         path: ~/.swiftpm
+         key: ${{ runner.os }}-swift-${{ hashFiles('**/Package.resolved') }}
+
       - name: Build iOS Simulator
         run: ./scripts/build-ios-simulator.sh
+
       - name: Run tests
         run: ./scripts/run-unit-tests.sh

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -1,6 +1,11 @@
 name: build-and-test
 run-name: build app from the ${{ github.head_ref }} branch
-on: pull_request
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "15 4,5 * * *"
+
 jobs:
   build-woof-target:
     runs-on: macos-14

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Run formater
+        continue-on-error: true
         run: |
          swiftformat --lint . \
          --config .swiftformat \

--- a/.swiftformat
+++ b/.swiftformat
@@ -2,14 +2,90 @@
 --funcattributes same-line
 --ranges no-space
 
-# rules enabled
---enable wrapEnumCases
+--disable all
 
-# rules disabled
---disable andOperator
---disable redundantPattern
---disable redundantLet
---disable wrapMultilineStatementBraces
+--enable \
+   anyObjectProtocol, \
+   applicationMain, \
+   assertionFailures, \
+   blankLinesAroundMark, \
+   blankLinesAtEndOfScope, \
+   blankLinesAtStartOfScope, \
+   blankLinesBetweenScopes, \
+   braces, \
+   conditionalAssignment, \
+   consecutiveBlankLines, \
+   consecutiveSpaces, \
+   duplicateImports, \
+   elseOnSameLine, \
+   emptyBraces, \
+   enumNamespaces, \
+   extensionAccessControl, \
+   fileHeader, \
+   genericExtensions, \
+   headerFileName, \
+   hoistAwait, \
+   hoistPatternLet, \
+   hoistTry, \
+   indent, \
+   initCoderUnavailable, \
+   leadingDelimiters, \
+   linebreakAtEndOfFile, \
+   linebreaks, \
+   modifierOrder, \
+   numberFormatting, \
+   opaqueGenericParameters, \
+   preferKeyPath, \
+   redundantBackticks, \
+   redundantBreak, \
+   redundantClosure, \
+   redundantExtensionACL, \
+   redundantFileprivate, \
+   redundantGet, \
+   redundantInit, \
+   redundantInternal, \
+   redundantLetError, \
+   redundantNilInit, \
+   redundantObjc, \
+   redundantOptionalBinding, \
+   redundantParens, \
+   redundantRawValues, \
+   redundantReturn, \
+   redundantSelf, \
+   redundantStaticSelf, \
+   redundantType, \
+   redundantVoidReturnType, \
+   semicolons, \
+   sortDeclarations, \
+   sortImports, \
+   sortTypealiases, \
+   spaceAroundBraces, \
+   spaceAroundBrackets, \
+   spaceAroundComments, \
+   spaceAroundGenerics, \
+   spaceAroundOperators, \
+   spaceAroundParens, \
+   spaceInsideBraces, \
+   spaceInsideBrackets, \
+   spaceInsideComments, \
+   spaceInsideGenerics, \
+   spaceInsideParens, \
+   strongOutlets, \
+   strongifiedSelf, \
+   todos, \
+   trailingClosures, \
+   trailingCommas, \
+   trailingSpace, \
+   typeSugar, \
+   unusedArguments, \
+   void, \
+   wrap, \
+   wrapArguments, \
+   wrapAttributes, \
+   wrapEnumCases, \
+   wrapSingleLineComments, \
+   yodaConditions
+
 
 # min swift format version
 --minversion 0.51.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Update `build-app.yml` to support required node.js version 20 - [#107](https://github.com/IronFoundation/iOS-Woof/pull/107)
 - Update the environment settings and documentation - [#108](https://github.com/IronFoundation/iOS-Woof/pull/108)
 - Update the `DetailedPetSitterView` to new style - [#106](https://github.com/IronFoundation/iOS-Woof/pull/106)
+- Update GitHub actions: update the workflow to run the tests and linters - [#126](https://github.com/IronFoundation/iOS-Woof/pull/126)
 
 ### Deleted
 

--- a/Woof/WoofTests/ViewModel/LoginViewModelTests.swift
+++ b/Woof/WoofTests/ViewModel/LoginViewModelTests.swift
@@ -17,39 +17,39 @@ final class LoginViewModelTests: XCTestCase {
         _ = viewModel
     }
 
-    func testOwnerFlowDidSelected_givenNoSavedOwner_whenIsCalled_thenShouldShowOwnerOnboardingIsTrue() {
+    func testownerRoleDidSelected_givenNoSavedOwner_whenIsCalled_thenShouldShowOwnerOnboardingIsTrue() {
         // Given // When
-        viewModel.ownerFlowDidSelected()
+        viewModel.ownerRoleDidSelected()
 
         // Then
         XCTAssertTrue(viewModel.shouldShowOwnerOnboarding)
     }
 
-    func testSitterFlowDidSelected_givenNoSavedSitter_whenIsCalled_thenShouldShowSitterOnboardingIsTrue() {
+    func testsitterRoleDidSelected_givenNoSavedSitter_whenIsCalled_thenShouldShowSitterOnboardingIsTrue() {
         // Given // When
-        viewModel.sitterFlowDidSelected()
+        viewModel.sitterRoleDidSelected()
 
         // Then
         XCTAssertTrue(viewModel.shouldShowSitterOnboarding)
     }
 
-    func testOwnerFlowDidSelected_givenSavedOwnerExists_whenIsCalled_thenShouldShowOwnerOnboardingIsFalse() {
+    func testownerRoleDidSelected_givenSavedOwnerExists_whenIsCalled_thenShouldShowOwnerOnboardingIsFalse() {
         // Given
         saveNewOwner()
 
         // When
-        viewModel.ownerFlowDidSelected()
+        viewModel.ownerRoleDidSelected()
 
         // Then
         XCTAssertFalse(viewModel.shouldShowOwnerOnboarding)
     }
 
-    func testSitterFlowDidSelected_givenSavedSitterExists_whenIsCalled_thenShouldShowSitterOnboardingIsFalse() {
+    func testsitterRoleDidSelected_givenSavedSitterExists_whenIsCalled_thenShouldShowSitterOnboardingIsFalse() {
         // Given
         saveNewSitter()
 
         // When
-        viewModel.sitterFlowDidSelected()
+        viewModel.sitterRoleDidSelected()
 
         // Then
         XCTAssertFalse(viewModel.shouldShowSitterOnboarding)

--- a/Woof/WoofTests/ViewModel/LoginViewModelTests.swift
+++ b/Woof/WoofTests/ViewModel/LoginViewModelTests.swift
@@ -17,7 +17,7 @@ final class LoginViewModelTests: XCTestCase {
         _ = viewModel
     }
 
-    func testownerRoleDidSelected_givenNoSavedOwner_whenIsCalled_thenShouldShowOwnerOnboardingIsTrue() {
+    func testOwnerFlowDidSelected_givenNoSavedOwner_whenIsCalled_thenShouldShowOwnerOnboardingIsTrue() {
         // Given // When
         viewModel.ownerRoleDidSelected()
 
@@ -25,7 +25,7 @@ final class LoginViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.shouldShowOwnerOnboarding)
     }
 
-    func testsitterRoleDidSelected_givenNoSavedSitter_whenIsCalled_thenShouldShowSitterOnboardingIsTrue() {
+    func testSitterFlowDidSelected_givenNoSavedSitter_whenIsCalled_thenShouldShowSitterOnboardingIsTrue() {
         // Given // When
         viewModel.sitterRoleDidSelected()
 
@@ -33,7 +33,7 @@ final class LoginViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.shouldShowSitterOnboarding)
     }
 
-    func testownerRoleDidSelected_givenSavedOwnerExists_whenIsCalled_thenShouldShowOwnerOnboardingIsFalse() {
+    func testOwnerFlowDidSelected_givenSavedOwnerExists_whenIsCalled_thenShouldShowOwnerOnboardingIsFalse() {
         // Given
         saveNewOwner()
 
@@ -44,7 +44,7 @@ final class LoginViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldShowOwnerOnboarding)
     }
 
-    func testsitterRoleDidSelected_givenSavedSitterExists_whenIsCalled_thenShouldShowSitterOnboardingIsFalse() {
+    func testSitterFlowDidSelected_givenSavedSitterExists_whenIsCalled_thenShouldShowSitterOnboardingIsFalse() {
         // Given
         saveNewSitter()
 

--- a/scripts/build-ios-simulator.sh
+++ b/scripts/build-ios-simulator.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly APP_NAME="Woof"
-readonly IOS_SDK="17.0"
+readonly IOS_SDK="17.4"
 
 source ~/.bash_profile
 cd ${APP_NAME}

--- a/scripts/build-ios-simulator.sh
+++ b/scripts/build-ios-simulator.sh
@@ -3,7 +3,9 @@
 readonly APP_NAME="Woof"
 readonly IOS_SDK="17.0"
 
+gem install xcpretty
+export PATH="$(gem environment gemdir)/bin:$PATH"
 xcodebuild -project ${APP_NAME}/${APP_NAME}.xcodeproj \
            -scheme ${APP_NAME} \
            -sdk iphonesimulator${IOS_SDK} \
-           -quiet
+           | xcpretty

--- a/scripts/build-ios-simulator.sh
+++ b/scripts/build-ios-simulator.sh
@@ -4,8 +4,6 @@ readonly APP_NAME="Woof"
 readonly IOS_SDK="17.0"
 
 xcodebuild -project ${APP_NAME}/${APP_NAME}.xcodeproj \
-           -scheme NetworkService
-xcodebuild -project ${APP_NAME}/${APP_NAME}.xcodeproj \
            -scheme ${APP_NAME} \
-           -configuration Release \
-           -sdk iphonesimulator${IOS_SDK}
+           -sdk iphonesimulator${IOS_SDK} \
+           -quiet

--- a/scripts/build-ios-simulator.sh
+++ b/scripts/build-ios-simulator.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly APP_NAME="Woof"
-readonly IOS_SDK="17.4"
+readonly IOS_SDK="17.2"
 
 source ~/.bash_profile
 cd ${APP_NAME}

--- a/scripts/build-ios-simulator.sh
+++ b/scripts/build-ios-simulator.sh
@@ -3,9 +3,9 @@
 readonly APP_NAME="Woof"
 readonly IOS_SDK="17.0"
 
-gem install xcpretty
-export PATH="$(gem environment gemdir)/bin:$PATH"
-xcodebuild -project ${APP_NAME}/${APP_NAME}.xcodeproj \
-           -scheme ${APP_NAME} \
-           -sdk iphonesimulator${IOS_SDK} \
-           | xcpretty
+source ~/.bash_profile
+cd ${APP_NAME}
+set -o pipefail && xcodebuild \
+-scheme ${APP_NAME} \
+-sdk iphonesimulator${IOS_SDK} \
+| xcpretty

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+readonly TEST_SCHEME="WoofTests"
+readonly DESTINATION_PLATFORM="iOS Simulator"
+readonly DESTINATION_NAME="iPhone 15 Pro"
+
+cd Woof
+xcodebuild \
+  -scheme "${TEST_SCHEME}" \
+  -sdk iphoneos \
+  -destination "platform=${DESTINATION_PLATFORM},name=${DESTINATION_NAME}" \
+  -quiet \
+  test

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -4,10 +4,10 @@ readonly TEST_SCHEME="WoofTests"
 readonly DESTINATION_PLATFORM="iOS Simulator"
 readonly DESTINATION_NAME="iPhone 15 Pro"
 
+source ~/.bash_profile
 cd Woof
-xcodebuild \
-  -scheme "${TEST_SCHEME}" \
-  -sdk iphoneos \
-  -destination "platform=${DESTINATION_PLATFORM},name=${DESTINATION_NAME}" \
-  -quiet \
-  test
+set -o pipefail && xcodebuild test \
+-scheme "${TEST_SCHEME}" \
+-sdk iphoneos \
+-destination "platform=${DESTINATION_PLATFORM},name=${DESTINATION_NAME}" \
+| xcpretty

--- a/scripts/set-up-environment.sh
+++ b/scripts/set-up-environment.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+readonly XCODE_VERSION="15.0.1"
+
+sudo xcode-select --switch /Applications/Xcode_${XCODE_VERSION}.app

--- a/scripts/set-up-environment.sh
+++ b/scripts/set-up-environment.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-readonly XCODE_VERSION="15.0.1"
-
-sudo xcode-select --switch /Applications/Xcode_${XCODE_VERSION}.app


### PR DESCRIPTION
## Summary
This PR is a part of the work to resolve #127.

## Changes
- Update script `build-ios-simulator.sh` (see listing-1):
  - `NetworkService` build is removed because that isn't reasonable for this project.
  - `-project` option is omitted because the `xcodebuild` command is called from the project directory and so that's not required.
  - Configuration is changed to `Debug` because `Release` doesn't give additional information but takes more time.
  - `source ~/.bash_profile` is required to add the path to `xcpretty` to the `PATH` environment variable.  
  - `xcpretty` serves to format build log into a more readable look. See [documentation](https://github.com/xcpretty/xcpretty).
  - `set -o pipefail && xcodebuild` allows to `xcpetty` exiting with the same status code as `xcodebuild`.

Listing-1:
```sh
source ~/.bash_profile
cd ${APP_NAME}
set -o pipefail && xcodebuild \
-scheme ${APP_NAME} \
-sdk iphonesimulator${IOS_SDK} \
| xcpretty
```

- Add script `run-unit-tests.sh` 

- Update workflow file:
	- Add [`on.workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) to enable a workflow to be triggered manually. 
	- Add [`on.schedule`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule)  to allow triggering a workflow at a scheduled time. To understand cron syntax follow to provided link to GitHub documentation. It's necessary for us to prevent cache from removing (see [eviction policy](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy)).
	- Add `actions/cache@v4` action to cache NetworkService package. It should prevent the package from downloading each time. For more info see [documentation](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy). Pay attention to the section [Restrictions for accessing a cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache). The `workflow_dispatch` and `schedule` are added to have access to the cache from a child branch, because these actions will trigger workflow from the main branch.
	- Add a new job that runs SwiftLint and SwiftFormat. Extracting these actions into a separate job allows running them concurrently on another runner.

- Update SwiftFormat config file: list explicitly all the rules to avoid automatically opting-in to new rules when SwiftFormat is updated. Accordingly to [documentation](https://github.com/nicklockwood/SwiftFormat#rules).


## Checks to complete
- [x] The PR title has a conventional commit style (short and descriptive).
- [x] The PR description includes essential information that helps understand the purpose of the changes.
- [x] I've built and run my changes, and no warnings or errors occurred.
- [x] All existing tests passed with my changes.
- [x] My code follows our style guide.
- [x] I've performed a self-review of my code.
- [x] I've updated `CHANGELOG.md` file.
- [x] PR has assignee, reviewers, milestone, it is properly linked to the project and to the issue.
